### PR TITLE
Create TranslationTest.md for markdown testing

### DIFF
--- a/docs/en/TranslationTest.md
+++ b/docs/en/TranslationTest.md
@@ -1,0 +1,340 @@
+# Sample Markdown Document
+
+If you define configuration items in the custom catalog and want configuration items to take effect when you query data, you can add the configuration items to the `PROPERTIES` parameter as key-value pairs when you create an external table. For example, if you define a configuration item `custom-catalog.properties` in the custom catalog, you can run the following command to create an external table.
+
+For example, create an Iceberg external table named `iceberg_tbl` in the database `iceberg_test`.
+
+For example, create a database named `iceberg_test` in StarRocks.
+
+For example, drop a resource named `iceberg0`.
+
+You can modify `hive.metastore.uris` and `iceberg.catalog-impl`of a Iceberg resource in StarRocks 2.3 and later versions. For more information, see [ALTER RESOURCE](../sql-reference/sql-statements/Resource/ALTER_RESOURCE.md).
+
+For example, create a resource named `iceberg1` and set the catalog type to `CUSTOM`.
+
+A custom catalog needs to inherit the abstract class BaseMetastoreCatalog, and you need to implement the IcebergCatalog interface. Additionally, the class name of a custom catalog cannot be duplicated with the name of the class that already exists in StarRock. After the catalog is created, package the catalog and its related files, and place them under the **fe/lib** path of each frontend (FE). Then restart each FE. After you complete the preceding operations, you can create a resource whose catalog is a custom catalog.
+
+
+| **Parameter**          | **Description**                                              |
+| ---------------------- | ------------------------------------------------------------ |
+| type                   | The resource type. Set the value to `iceberg`.               |
+| iceberg.catalog.type | The catalog type of the resource. Both Hive catalog and custom catalog are supported. If you specify a Hive catalog, set the value to `HIVE`. If you specify a custom catalog, set the value to `CUSTOM`. |
+| iceberg.catalog-impl   | The fully qualified class name of the custom catalog. FEs search for the catalog based on this name. If the catalog contains custom configuration items, you must add them to the `PROPERTIES` parameter as key-value pairs when you create an Iceberg external table. |
+
+
+For example, create a resource named `iceberg0` and set the catalog type to `HIVE`.
+
+* If the metadata of an Iceberg table is obtained from a Hive metastore, you can create a resource and set the catalog type to `HIVE`.
+
+* geo-related query
+
+* Create a Hive resource named `hive0`.
+
+Example: Create the external table `profile_parquet_p7` under the `rawdata` database in the Hive cluster corresponding to the `hive0` resource.
+
+The **esquery function** is used to push down queries **that cannot be expressed in SQL** (such as match and geoshape) to Elasticsearch for filtering. The first parameter in the esquery function is used to associate an index. The second parameter is a JSON expression of basic Query DSL, which is enclosed in brackets {}. **The JSON expression must have but only one root key**, such as match, geo_shape, or bool.
+
+For supported data types and data type mapping between StarRocks and target databases, see [Data type mapping](External_table.md#Data type mapping).
+
+This is a sample markdown document that demonstrates various markdown elements for testing the translation tool.
+
+## Introduction
+
+Welcome to the **Markdown Translator** testing document! This file contains various markdown elements to ensure that translations preserve formatting correctly.
+
+### Features to Test
+
+Here are the key features we want to verify:
+
+1. **Headers** of different levels
+2. *Italic* and **bold** text formatting
+3. `Inline code` snippets
+4. Lists (ordered and unordered)
+5. Links and images
+6. Code blocks
+7. Tables
+8. Blockquotes
+
+## Code Examples
+
+Here's a JavaScript function that should remain untranslated:
+
+```javascript
+function greetUser(name) {
+    console.log(`Hello, ${name}! Welcome to the translator.`);
+    return `Greeting sent to ${name}`;
+}
+```
+
+And here's some Python code:
+
+```python
+def calculate_total(items):
+    """Calculate the total price of items."""
+    total = sum(item['price'] for item in items)
+    return total
+```
+
+## Lists
+
+### Unordered List
+
+- First item in the list
+- Second item with **bold text**
+- Third item with [a link](https://example.com)
+- Fourth item with `inline code`
+
+### Ordered List
+
+1. Primary step in the process
+2. Secondary step with *emphasis*
+3. Final step with important details
+
+## Tables
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| Translation | Convert text to target language | ✅ Active |
+| Formatting | Preserve markdown structure | ✅ Active |
+| Code Blocks | Keep code untranslated | ✅ Active |
+| Links | Maintain URL integrity | ✅ Active |
+
+## Links and Images
+
+Visit our [documentation](https://github.com/example/markdown-translator) for more information.
+
+![Sample Image](https://via.placeholder.com/300x200?text=Sample+Image)
+
+## Docusaurus admonitions
+
+:::tip
+If there are no access keys showing in the MinIO web UI, check the logs of the `minio_mc` service:
+
+```bash
+docker compose logs minio_mc
+```
+
+Try rerunning the `minio_mc` pod:
+
+```bash
+docker compose run minio_mc
+```
+:::
+
+## Blockquotes
+
+> This is an important quote that should be translated while preserving the blockquote formatting.
+> 
+> Multiple paragraph quotes should also work correctly.
+
+### Nested Blockquotes
+
+> This is a main quote.
+> 
+> > This is a nested quote within the main quote.
+> > It should maintain proper nesting structure.
+
+## Mixed Content
+
+You can combine `inline code` with **bold text** and *italic text* in the same paragraph. URLs like https://example.com should remain unchanged, as should email addresses like contact@example.com.
+
+## Technical Terms
+
+When dealing with technical documentation, terms like **API**, **JSON**, **HTTP**, and **URL** might need special handling depending on the target language and context.
+
+This sample also intentionally includes several project-specific terms that must NOT be translated: StarRocks, Hive, Leader, Follower, Raft, Docker, Kubernetes, MinIO.
+
+Additional example sentences using common English terms from the Chinese dictionary:
+
+- Data loading is performed during the ingestion phase of the pipeline.
+- Data unloading exports results to external systems for downstream processing.
+- A native table stores data using the system's internal format.
+- Cloud-native table deployments separate storage and compute for scalability.
+- An External Table allows querying data that lives outside the database.
+- A Hive external table can be used to access legacy Hive datasets.
+- Storage layering helps optimize hot and cold data placement.
+- The separation of storage and compute enables flexible scaling.
+- In shared-data mode, multiple compute clusters access the same storage.
+- Zero-migration strategies minimize downtime during upgrades.
+- The native vectorized engine accelerates analytical queries.
+- Query federation allows joining tables across different systems.
+- Columnar storage improves compression and analytical performance.
+- Row storage is useful for transactional workloads.
+- A materialized view can precompute expensive aggregations.
+- Pre-aggregation reduces work at query time by summarizing data ahead of time.
+- An aggregate query computes summaries across groups of rows.
+- A star schema is a common dimensional modeling pattern for analytics.
+- The snowflake schema normalizes dimension tables to reduce redundancy.
+- A point query retrieves a single row or a small set of rows by key.
+
+### Code with Explanations
+
+The following command installs the package:
+
+```bash
+npm install markdown-translator
+```
+
+This command should remain exactly as written, but this explanation text should be translated.
+
+## Conclusion
+
+This sample document tests various markdown elements to ensure the translation tool works correctly. The goal is to translate all readable text while preserving:
+
+- Markdown formatting
+- Code blocks and inline code
+- URLs and file paths
+- Technical syntax
+
+---
+
+*This document was created for testing purposes.* 
+
+# External table
+
+Execute the following statement to create a JDBC resource named `jdbc0`:
+
+When the resource is being created, the FE downloads the JDBC driver JAR package by using the URL that is specified in the `driver_url` parameter, generates a checksum, and uses the checksum to verify the JDBC driver downloaded by BEs.
+
+From 2.5 onwards, StarRocks provides the Data Cache feature, which accelerates hot data queriers on external data sources. For more information, see [Data Cache](data_cache.md).
+
+When BEs query the JDBC external table for the first time and find that the corresponding JDBC driver JAR package does not exist on their machines, BEs download the JDBC driver JAR package by using the URL that is specified in the `driver_url` parameter, and all JDBC driver JAR packages are saved in the `${STARROCKS_HOME}/lib/jdbc_drivers` directory.
+
+> Note: The `ResourceType` column is `jdbc`.
+
+Execute the following statement to delete the JDBC resource named `jdbc0`:
+
+Execute the following statement to create and access a database named `jdbc_test` in StarRocks:
+
+Execute the following statement to create a JDBC external table named `jdbc_tbl` in the database `jdbc_test`:
+
+The required parameters in `properties` are as follows:
+
+Execute the following statement to delete the Hudi resource named `hudi0`:
+
+Execute the following statement to create and open a Hudi database named `hudi_test` in your StarRocks cluster:
+
+The following table describes the parameters.
+
+| Parameter | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| ENGINE    | The query engine of the Hudi external table. Set the value to `HUDI`. |
+| resource  | The name of the Hudi resource in your StarRocks cluster.     |
+| database  | The name of the Hudi database to which the Hudi external table belongs in your StarRocks cluster. |
+| table     | The Hudi managed table with which the Hudi external table is associated. |
+
+| Data types supported by Hudi   | Data types supported by StarRocks |
+| ----------------------------   | --------------------------------- |
+| BOOLEAN                        | BOOLEAN                           |
+| INT                            | TINYINT/SMALLINT/INT              |
+| DATE                           | DATE                              |
+| TimeMillis/TimeMicros          | TIME                              |
+| TimestampMillis/TimestampMicros| DATETIME                          |
+| LONG                           | BIGINT                            |
+| FLOAT                          | FLOAT                             |
+| DOUBLE                         | DOUBLE                            |
+| STRING                         | CHAR/VARCHAR                      |
+| ARRAY                          | ARRAY                             |
+| DECIMAL                        | DECIMAL                           |
+
+:::note
+
+StarRocks does not support querying data of the STRUCT or MAP type, nor does it support querying data of the ARRAY type in Merge On Read tables.
+
+:::
+
+> **Note**
+>
+> StarRocks does not support querying data of the STRUCT or MAP type, nor does it support querying data of the ARRAY type in Merge On Read tables.
+
+:::note
+
+The External Table feature is no longer recommended except for certain corner usage cases, and might be deprecated in future releases. To manage and query data from external data sources in general scenarios, [External Catalog](./catalog/catalog_overview.md) is recommended.
+
+:::
+
+The following table describes the parameters.
+
+| **Parameter**        | **Required** | **Default value** | **Description**                                              |
+| -------------------- | ------------ | ----------------- | ------------------------------------------------------------ |
+| hosts                | Yes          | None              | The connection address of the Elasticsearch cluster. You can specify one or more addresses. StarRocks can parse the Elasticsearch version and index shard allocation from this address. StarRocks communicates with your Elasticsearch cluster based on the address returned by the `GET /_nodes/http` API operation. Therefore, the value of the `host` parameter must be the same as the address returned by the `GET /_nodes/http` API operation. Otherwise, BEs may not be able to communicate with your Elasticsearch cluster. |
+| index                | Yes          | None              | The name of the Elasticsearch index that is created on the table in StarRocks. The name can be an alias. This parameter supports wildcards (\*). For example, if you set `index` to <code class="language-text">hello*</code>, StarRocks retrieves all indexes whose names start with `hello`. |
+| user                 | No           | Empty             | The username that is used to log in to the Elasticsearch cluster with basic authentication enabled. Make sure you have access to `/*cluster/state/*nodes/http` and the index. |
+| password             | No           | Empty             | The password that is used to log in to the Elasticsearch cluster. |
+| type                 | No           | `_doc`            | The type of the index. Default value: `_doc`. If you want to query data in Elasticsearch 8 and later versions, you do not need to configure this parameter because the mapping types have been removed in Elasticsearch 8 and later versions. |
+| es.nodes.wan.only    | No           | `false`           | Specifies whether StarRocks only uses the addresses specified by `hosts` to access the Elasticsearch cluster and fetch data.<ul><li>`true`: StarRocks only uses the addresses specified by `hosts` to access the Elasticsearch cluster and fetch data and does not sniff data nodes on which the shards of the Elasticsearch index reside. If StarRocks cannot access the addresses of the data nodes inside the Elasticsearch cluster, you need to set this parameter to `true`.</li><li>`false`: StarRocks uses the addresses specified by `host` to sniff data nodes on which the shards of the Elasticsearch cluster indexes reside. After StarRocks generates a query execution plan, the relevant BEs directly access the data nodes inside the Elasticsearch cluster to fetch data from the shards of indexes. If StarRocks can access the addresses of the data nodes inside the Elasticsearch cluster, we recommend that you retain the default value `false`.</li></ul> |
+| es.net.ssl           | No           | `false`           | Specifies whether the HTTPS protocol can be used to access your Elasticsearch cluster. Only StarRocks 2.4 and later versions support configuring this parameter.<ul><li>`true`: Both the HTTPS and HTTP protocols can be used to access your Elasticsearch cluster.</li><li>`false`: Only the HTTP protocol can be used to access your Elasticsearch cluster.</li></ul> |
+| enable_docvalue_scan | No           | `true`            | Specifies whether to obtain the values of the target fields from Elasticsearch columnar storage. In most cases, reading data from columnar storage outperforms reading data from row storage. |
+| enable_keyword_sniff | No           | `true`            | Specifies whether to sniff TEXT-type fields in Elasticsearch based on KEYWORD-type fields. If this parameter is set to `false`, StarRocks performs matching after tokenization. |
+
+|   SQL syntax  |   ES syntax  |
+| :---: | :---: |
+|  `=`   |  term query   |
+|  `in`   |  terms query   |
+|  `>=,  <=, >, <`   |  range   |
+|  `and`   |  bool.filter   |
+|  `or`   |  bool.should   |
+|  `not`   |  bool.must_not   |
+|  `not in`   |  bool.must_not + terms   |
+|  `esquery`   |  ES Query DSL  |
+
+> Note:
+>
+> * Currently, the supported Hive storage formats are Parquet, ORC, and CSV.
+If the storage format is CSV, quotation marks cannot be used as escape characters.
+> * The SNAPPY and LZ4 compression formats are supported.
+> * The maximum length of a Hive string column that can be queried is 1 MB. If a string column exceeds 1 MB, it will be processed as a null column.
+
+The first field of `k4` is TEXT, and it will be tokenized by the analyzer configured for `k4` (or by the standard analyzer if no analyzer has been configured for `k4`) after data ingestion. As a result, the first field will be tokenized into three terms: `StarRocks`, `On`, and `Elasticsearch`. The details are as follows:
+
+* **user:** This parameter specifies the username used to access the destination StarRocks cluster.
+* **password:** This parameter specifies the password used to access the destination StarRocks cluster.
+* **database:** This parameter specifies the database to which the destination table belongs.
+* **table:** This parameter specifies the name of the destination table.
+
+~~~SQL
+# Create a destination table in the destination StarRocks cluster.
+CREATE TABLE t
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    k4 VARCHAR(2048),
+    k5 DATETIME
+)
+ENGINE=olap
+DISTRIBUTED BY HASH(k1);
+
+# Create an external table in the source StarRocks cluster.
+CREATE EXTERNAL TABLE external_t
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    k4 VARCHAR(2048),
+    k5 DATETIME
+)
+ENGINE=olap
+DISTRIBUTED BY HASH(k1)
+PROPERTIES
+(
+    "host" = "127.0.0.1",
+    "port" = "9020",
+    "user" = "user",
+    "password" = "passwd",
+    "database" = "db_test",
+    "table" = "t"
+);
+
+# Write data from a source cluster to a destination cluster by writing data into the StarRocks external table. The second statement is recommended for the production environment.
+insert into external_t values ('2020-10-11', 1, 1, 'hello', '2020-10-11 10:00:00');
+insert into external_t select * from other_table;
+~~~
+
+## References
+
+- [SHOW CREATE TABLE](SHOW_CREATE_TABLE.md)
+- [SHOW TABLES](SHOW_TABLES.md)
+- [USE](../Database/USE.md)
+- [ALTER TABLE](ALTER_TABLE.md)
+- [DROP TABLE](DROP_TABLE.md)

--- a/docs/ja/TranslationTest.md
+++ b/docs/ja/TranslationTest.md
@@ -1,0 +1,339 @@
+# サンプル Markdown ドキュメント
+
+カスタムカタログで設定項目を定義し、データをクエリする際にその設定項目を有効にしたい場合は、外部テーブルを作成するときに `PROPERTIES` パラメータにキーと値のペアとして設定項目を追加できます。たとえば、カスタムカタログで設定項目 `custom-catalog.properties` を定義した場合、次のコマンドを実行して外部テーブルを作成できます。
+
+たとえば、データベース `iceberg_test` に `iceberg_tbl` という名前の Iceberg 外部テーブルを作成します。
+
+たとえば、StarRocks に `iceberg_test` という名前のデータベースを作成します。
+
+たとえば、`iceberg0` という名前のリソースを削除します。
+
+StarRocks 2.3 以降のバージョンでは、Iceberg リソースの `hive.metastore.uris` および `iceberg.catalog-impl` を変更できます。詳細については、[ALTER RESOURCE](../sql-reference/sql-statements/Resource/ALTER_RESOURCE.md)。
+
+たとえば、`iceberg1` という名前のリソースを作成し、カタログタイプを `CUSTOM` に設定します。
+
+カスタムカタログは抽象クラス BaseMetastoreCatalog を継承する必要があり、IcebergCatalog インターフェースを実装する必要があります。また、カスタムカタログのクラス名は、StarRocks にすでに存在するクラスの名前と重複することはできません。カタログを作成したら、カタログとその関連ファイルをパッケージ化し、各フロントエンド（FE）の**fe/lib** パスに配置します。その後、各 FE を再起動します。上記の操作が完了したら、カタログがカスタムカタログであるリソースを作成できます。
+
+| **パラメータ**          | **説明**                                              |
+| ---------------------- | ------------------------------------------------------------ |
+| type                   | リソースタイプ。値を `iceberg` に設定します。               |
+| iceberg.catalog.type | リソースのカタログタイプ。Hive カタログとカスタムカタログの両方がサポートされています。Hive カタログを指定する場合は、値を `HIVE` に設定します。カスタムカタログを指定する場合は、値を `CUSTOM` に設定します。 |
+| iceberg.catalog-impl   | カスタムカタログの完全修飾クラス名。FE はこの名前に基づいてカタログを検索します。カタログにカスタム設定項目が含まれている場合は、Iceberg 外部テーブルを作成するときに `PROPERTIES` パラメータにキーと値のペアとして追加する必要があります。 |
+
+たとえば、`iceberg0` という名前のリソースを作成し、カタログタイプを `HIVE` に設定します。
+
+- Iceberg テーブルのメタデータが Hive メタストアから取得される場合は、リソースを作成してカタログタイプを `HIVE` に設定できます。
+
+- 地理空間関連クエリ
+
+- `hive0` という名前の Hive リソースを作成します。
+
+例：`hive0` リソースに対応する Hive クラスターの `rawdata` データベース配下に外部テーブル `profile_parquet_p7` を作成します。
+
+**esquery 関数** はクエリをプッシュダウンするために使用されます **SQL では表現できない** （match や geoshape など）を Elasticsearch にフィルタリングのために送信します。esquery 関数の最初のパラメータはインデックスの関連付けに使用されます。2 番目のパラメータは基本的な Query DSL の JSON 式であり、括弧 {} で囲まれています。**JSON 式はルートキーを 1 つだけ持つ必要があります**（match、geo_shape、bool など）。
+
+サポートされているデータ型および StarRocks とターゲットデータベース間のデータ型マッピングについては、[データ型マッピング](External_table.md#Data type mapping) を参照してください。
+
+これは、翻訳ツールのテスト用にさまざまな Markdown 要素を示すサンプル Markdown ドキュメントです。
+
+## はじめに
+
+**Markdown トランスレーター** テストドキュメントへようこそ！このファイルには、翻訳がフォーマットを正しく保持することを確認するためのさまざまな Markdown 要素が含まれています。
+
+### テストする機能
+
+検証したい主な機能は次のとおりです：
+
+1. **見出し** さまざまなレベルの
+2. *イタリック* と **太字** テキスト書式設定
+3. `Inline code` スニペット
+4. リスト（順序付きおよび順序なし）
+5. リンクと画像
+6. コードブロック
+7. テーブル
+8. ブロック引用
+
+## コード例
+
+以下は翻訳されないままにすべきJavaScript関数です：
+
+```javascript
+function greetUser(name) {
+    console.log(`Hello, ${name}! Welcome to the translator.`);
+    return `Greeting sent to ${name}`;
+}
+```
+
+以下はPythonコードです：
+
+```python
+def calculate_total(items):
+    """Calculate the total price of items."""
+    total = sum(item['price'] for item in items)
+    return total
+```
+
+## リスト
+
+### 順序なしリスト
+
+- リストの最初の項目
+- 2番目の項目（**太字テキスト**
+- 3番目の項目（[リンク](https://example.com)
+- 4番目の項目（`inline code`）
+
+### 順序付きリスト
+
+1. プロセスの最初のステップ
+2. 2番目のステップ（*強調*
+3. 重要な詳細を含む最終ステップ
+
+## テーブル
+
+| 機能 | 説明 | ステータス |
+|---------|-------------|--------|
+| 翻訳 | テキストをターゲット言語に変換 | ✅ 有効 |
+| 書式設定 | Markdown構造を保持 | ✅ 有効 |
+| コードブロック | コードを翻訳せずに保持 | ✅ 有効 |
+| リンク | URLの整合性を維持 | ✅ 有効 |
+
+## リンクと画像
+
+詳細については、[ドキュメント](https://github.com/example/markdown-translator) をご覧ください。
+
+![サンプル画像](https://via.placeholder.com/300x200?text=Sample+Image)
+
+## Docusaurus admonitions
+
+:::tip
+MinIO Web UIにアクセスキーが表示されない場合は、`minio_mc` サービスのログを確認してください：
+
+```bash
+docker compose logs minio_mc
+```
+
+`minio_mc` ポッドを再実行してみてください：
+
+```bash
+docker compose run minio_mc
+```
+
+:::
+
+## ブロック引用
+
+> これはブロック引用の書式を保持しながら翻訳されるべき重要な引用です。
+>
+> 複数段落の引用も正しく機能するはずです。
+
+### ネストされたブロック引用
+
+> これはメインの引用です。
+>
+> > これはメインの引用内のネストされた引用です。
+適切なネスト構造を維持する必要があります。
+
+## 混合コンテンツ
+
+同じ段落内で `inline code` と組み合わせることができます。**太字テキスト** と *斜体テキスト* を同じ段落内で使用できます。https://example.com のような URL は変更されず、contact@example.com のようなメールアドレスも同様です。
+
+## 技術用語
+
+技術ドキュメントを扱う場合、**API**、**JSON**、**HTTP**、および **URL** などの用語は、対象言語とコンテキストによって特別な処理が必要になる場合があります。
+
+このサンプルには、翻訳してはならないプロジェクト固有の用語も意図的に含まれています: StarRocks、Hive、Leader、Follower、Raft、Docker、Kubernetes、MinIO。
+
+中国語辞書の一般的な英語用語を使用した追加の例文:
+
+- データのロードはパイプラインのインジェストフェーズ中に実行されます。
+- データのアンロードは、ダウンストリーム処理のために外部システムに結果をエクスポートします。
+- ネイティブテーブルはシステムの内部フォーマットを使用してデータを保存します。
+- クラウドネイティブテーブルのデプロイメントは、スケーラビリティのためにストレージとコンピュートを分離します。
+- 外部テーブルを使用すると、データベースの外部に存在するデータをクエリできます。
+- Hive 外部テーブルを使用して、レガシーな Hive データセットにアクセスできます。
+- ストレージの階層化は、ホットデータとコールドデータの配置を最適化するのに役立ちます。
+- ストレージとコンピュートの分離により、柔軟なスケーリングが可能になります。
+- 共有データモードでは、複数のコンピュートクラスターが同じストレージにアクセスします。
+- ゼロマイグレーション戦略は、アップグレード中のダウンタイムを最小化します。
+- ネイティブベクトル化エンジンは分析クエリを高速化します。
+- クエリフェデレーションにより、異なるシステム間でテーブルを結合できます。
+- カラム型ストレージは圧縮と分析パフォーマンスを向上させます。
+- 行ストレージはトランザクションワークロードに役立ちます。
+- マテリアライズドビューは、コストのかかる集計を事前に計算できます。
+- 事前集計は、データを事前に集約することでクエリ時の処理を削減します。
+- 集計クエリは、行のグループ全体の集計を計算します。
+- スタースキーマは、分析のための一般的なディメンショナルモデリングパターンです。
+- スノーフレークスキーマは、冗長性を削減するためにディメンションテーブルを正規化します。
+- ポイントクエリは、キーによって単一の行または少数の行を取得します。
+
+### 説明付きコード
+
+次のコマンドはパッケージをインストールします：
+
+```bash
+npm install markdown-translator
+```
+
+このコマンドは記載されたとおりに保持する必要がありますが、この説明テキストは翻訳する必要があります。
+
+## 結論
+
+このサンプルドキュメントは、翻訳ツールが正しく機能することを確認するために、さまざまなマークダウン要素をテストします。目標は、以下を保持しながらすべての読み取り可能なテキストを翻訳することです：
+
+- マークダウンの書式設定
+- コードブロックとインラインコード
+- URLとファイルパス
+- 技術的な構文
+
+***
+
+*このドキュメントはテスト目的で作成されました。*
+
+# 外部テーブル
+
+次のステートメントを実行して、`jdbc0` という名前のJDBCリソースを作成します：
+
+リソースの作成時に、FEは `driver_url` パラメータで指定されたURLを使用してJDBCドライバーJARパッケージをダウンロードし、チェックサムを生成して、BEがダウンロードしたJDBCドライバーの検証に使用します。
+
+2.5以降、StarRocksはデータキャッシュ機能を提供しており、外部データソースのホットデータクエリを高速化します。詳細については、[データキャッシュ](data_cache.md)。
+
+BEが初めてJDBC外部テーブルをクエリし、対応するJDBCドライバーJARパッケージがマシン上に存在しないことを確認した場合、BEは `driver_url` パラメータで指定されたURLを使用してJDBCドライバーJARパッケージをダウンロードし、すべてのJDBCドライバーJARパッケージは `${STARROCKS_HOME}/lib/jdbc_drivers` ディレクトリに保存されます。
+
+> 注意：`ResourceType` 列は `jdbc` です。
+
+次のステートメントを実行して、`jdbc0` という名前のJDBCリソースを削除します：
+
+次のステートメントを実行して、StarRocksで `jdbc_test` という名前のデータベースを作成してアクセスします：
+
+次のステートメントを実行して、データベース `jdbc_test` に `jdbc_tbl` という名前のJDBC外部テーブルを作成します：
+
+`properties` の必須パラメータは以下のとおりです：
+
+次のステートメントを実行して、`hudi0` という名前のHudiリソースを削除します：
+
+次のステートメントを実行して、StarRocksクラスターに `hudi_test` という名前のHudiデータベースを作成して開きます：
+
+次の表にパラメータを説明します。
+
+| パラメータ | 説明                                                  |
+| --------- | ------------------------------------------------------------ |
+| ENGINE    | Hudi外部テーブルのクエリエンジン。値を `HUDI` に設定します。 |
+| resource  | StarRocksクラスター内のHudiリソースの名前。     |
+| database  | StarRocksクラスター内でHudi外部テーブルが属するHudiデータベースの名前。 |
+| table     | Hudi外部テーブルが関連付けられているHudi管理テーブル。 |
+
+| Hudiがサポートするデータ型   | StarRocksがサポートするデータ型 |
+| ----------------------------   | --------------------------------- |
+| BOOLEAN                        | BOOLEAN                           |
+| INT                            | TINYINT/SMALLINT/INT              |
+| DATE                           | DATE                              |
+| TimeMillis/TimeMicros          | TIME                              |
+| TimestampMillis/TimestampMicros| DATETIME                          |
+| LONG                           | BIGINT                            |
+| FLOAT                          | FLOAT                             |
+| DOUBLE                         | DOUBLE                            |
+| STRING                         | CHAR/VARCHAR                      |
+| ARRAY                          | ARRAY                             |
+| DECIMAL                        | DECIMAL                           |
+
+:::note
+
+StarRocksは、STRUCTまたはMAP型のデータのクエリをサポートしておらず、Merge On ReadテーブルでのARRAY型のデータのクエリもサポートしていません。
+
+:::
+
+> **注意**
+>
+> StarRocksは、STRUCTまたはMAP型のデータのクエリをサポートしておらず、Merge On ReadテーブルでのARRAY型のデータのクエリもサポートしていません。
+
+:::note
+
+外部テーブル機能は、特定のコーナーユースケースを除いて推奨されなくなり、将来のリリースで非推奨になる可能性があります。一般的なシナリオで外部データソースのデータを管理およびクエリするには、[外部カタログ](./catalog/catalog_overview.md)を推奨します。
+
+:::
+
+次の表にパラメータを説明します。
+
+| **パラメーター**        | **必須** | **デフォルト値** | **説明**                                              |
+| -------------------- | ------------ | ----------------- | ------------------------------------------------------------ |
+| hosts                | Yes          | None              | Elasticsearchクラスターの接続アドレス。1つ以上のアドレスを指定できます。StarRocksはこのアドレスからElasticsearchのバージョンとインデックスシャードの割り当てを解析します。StarRocksは`GET /_nodes/http` API操作によって返されたアドレスに基づいてElasticsearchクラスターと通信します。そのため、`host`パラメーターの値は`GET /_nodes/http` API操作によって返されたアドレスと同じである必要があります。そうでない場合、BEがElasticsearchクラスターと通信できない可能性があります。 |
+| index                | Yes          | None              | StarRocksのテーブルに作成されたElasticsearchインデックスの名前。エイリアスも使用できます。このパラメーターはワイルドカード（*）をサポートしています。たとえば、`index`を <code class="language-text">hello*</code>に設定すると、StarRocksは`hello`で始まる名前のすべてのインデックスを取得します。 |
+| user                 | No           | Empty             | 基本認証が有効なElasticsearchクラスターへのログインに使用するユーザー名。`/*cluster/state/*nodes/http`およびインデックスへのアクセス権があることを確認してください。 |
+| password             | No           | Empty             | Elasticsearchクラスターへのログインに使用するパスワード。 |
+| type                 | No           | `_doc`            | インデックスのタイプ。デフォルト値：`_doc`。Elasticsearch 8以降のバージョンのデータをクエリする場合、マッピングタイプがElasticsearch 8以降で削除されているため、このパラメーターを設定する必要はありません。 |
+| es.nodes.wan.only    | No           | `false`           | StarRocksが`hosts`で指定されたアドレスのみを使用してElasticsearchクラスターにアクセスしデータを取得するかどうかを指定します。<ul><li>`true`：StarRocksは`hosts`で指定されたアドレスのみを使用してElasticsearchクラスターにアクセスしデータを取得し、Elasticsearchインデックスのシャードが存在するデータノードをスニッフィングしません。StarRocksがElasticsearchクラスター内部のデータノードのアドレスにアクセスできない場合、このパラメーターを`true`に設定する必要があります。</li><li>`false`：StarRocksは`host`で指定されたアドレスを使用して、Elasticsearchクラスターインデックスのシャードが存在するデータノードをスニッフィングします。StarRocksがクエリ実行計画を生成した後、関連するBEはElasticsearchクラスター内部のデータノードに直接アクセスし、インデックスのシャードからデータを取得します。StarRocksがElasticsearchクラスター内部のデータノードのアドレスにアクセスできる場合、デフォルト値`false`を維持することをお勧めします。</li></ul> |
+| es.net.ssl           | No           | `false`           | ElasticsearchクラスターへのアクセスにHTTPSプロトコルを使用できるかどうかを指定します。このパラメーターの設定はStarRocks 2.4以降のバージョンのみサポートされています。<ul><li>`true`：HTTPSおよびHTTPプロトコルの両方をElasticsearchクラスターへのアクセスに使用できます。</li><li>`false`：HTTPプロトコルのみをElasticsearchクラスターへのアクセスに使用できます。</li></ul> |
+| enable_docvalue_scan | No           | `true`            | Elasticsearchのカラム型ストレージから対象フィールドの値を取得するかどうかを指定します。ほとんどの場合、カラム型ストレージからのデータ読み取りは行型ストレージからの読み取りよりも優れたパフォーマンスを発揮します。 |
+| enable_keyword_sniff | No           | `true`            | KYEWORDタイプのフィールドに基づいてElasticsearchのTEXTタイプフィールドをスニッフィングするかどうかを指定します。このパラメーターが`false`に設定されている場合、StarRocksはトークン化後にマッチングを実行します。 |
+
+|   SQL構文  |   ES構文  |
+| :---: | :---: |
+|  `=`   |  term query   |
+|  `in`   |  terms query   |
+|  `>=,  <=, >, <`   |  range   |
+|  `and`   |  bool.filter   |
+|  `or`   |  bool.should   |
+|  `not`   |  bool.must_not   |
+|  `not in`   |  bool.must_not + terms   |
+|  `esquery`   |  ES Query DSL  |
+
+> 注意：
+>
+> - 現在、サポートされているHiveストレージ形式はParquet、ORC、およびCSVです。
+ストレージ形式がCSVの場合、引用符をエスケープ文字として使用することはできません。
+> - SNAPPYおよびLZ4圧縮形式がサポートされています。
+> - クエリ可能なHive文字列カラムの最大長は1 MBです。文字列カラムが1 MBを超える場合、nullカラムとして処理されます。
+
+`k4`の最初のフィールドはTEXTであり、データ取り込み後に`k4`に設定されたアナライザー（`k4`にアナライザーが設定されていない場合は標準アナライザー）によってトークン化されます。その結果、最初のフィールドは`StarRocks`、`On`、`Elasticsearch`の3つのタームにトークン化されます。詳細は以下のとおりです：
+
+- **user:** このパラメーターは、宛先StarRocksクラスターへのアクセスに使用するユーザー名を指定します。
+- **password:** このパラメーターは、宛先StarRocksクラスターへのアクセスに使用するパスワードを指定します。
+- **database:** このパラメーターは、宛先テーブルが属するデータベースを指定します。
+- **table:** このパラメーターは、宛先テーブルの名前を指定します。
+
+```SQL
+# 宛先StarRocksクラスターに宛先テーブルを作成します。
+CREATE TABLE t
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    k4 VARCHAR(2048),
+    k5 DATETIME
+)
+ENGINE=olap
+DISTRIBUTED BY HASH(k1);
+
+# ソースStarRocksクラスターに外部テーブルを作成します。
+CREATE EXTERNAL TABLE external_t
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    k4 VARCHAR(2048),
+    k5 DATETIME
+)
+ENGINE=olap
+DISTRIBUTED BY HASH(k1)
+PROPERTIES
+(
+    "host" = "127.0.0.1",
+    "port" = "9020",
+    "user" = "user",
+    "password" = "passwd",
+    "database" = "db_test",
+    "table" = "t"
+);
+
+# StarRocks外部テーブルにデータを書き込むことで、ソースクラスターから宛先クラスターにデータを書き込みます。本番環境では2番目のステートメントを推奨します。
+insert into external_t values ('2020-10-11', 1, 1, 'hello', '2020-10-11 10:00:00');
+insert into external_t select * from other_table;
+```
+
+## 参考資料
+
+- [SHOW CREATE TABLE](SHOW_CREATE_TABLE.md)
+- [SHOW TABLES](SHOW_TABLES.md)
+- [USE](../Database/USE.md)
+- [ALTER TABLE](ALTER_TABLE.md)
+- [DROP TABLE](DROP_TABLE.md)

--- a/docs/zh/TranslationTest.md
+++ b/docs/zh/TranslationTest.md
@@ -1,0 +1,339 @@
+# 示例 Markdown 文档
+
+如果您在自定义 catalog 中定义了配置项，并希望在查询数据时使配置项生效，可以在创建外部表时将配置项作为键值对添加到 `PROPERTIES` 参数中。例如，如果您在自定义 catalog 中定义了配置项 `custom-catalog.properties`，可以运行以下命令创建外部表。
+
+例如，在数据库 `iceberg_test` 中创建名为 `iceberg_tbl` 的 Iceberg 外部表。
+
+例如，在 StarRocks 中创建名为 `iceberg_test` 的数据库。
+
+例如，删除名为 `iceberg0` 的资源。
+
+您可以在 StarRocks 2.3 及更高版本中修改 Iceberg 资源的 `hive.metastore.uris` 和 `iceberg.catalog-impl`。更多信息，请参见[ALTER RESOURCE](../sql-reference/sql-statements/Resource/ALTER_RESOURCE.md)。
+
+例如，创建名为 `iceberg1` 的资源，并将 catalog 类型设置为 `CUSTOM`。
+
+自定义 catalog 需要继承抽象类 BaseMetastoreCatalog，并且您需要实现 IcebergCatalog 接口。此外，自定义 catalog 的类名不能与 StarRocks 中已存在的类名重复。创建 catalog 后，将 catalog 及其相关文件打包，并放置在每个前端（FE）的**fe/lib** 路径下。然后重启每个 FE。完成上述操作后，您可以创建一个以自定义 catalog 为 catalog 的资源。
+
+| **参数**          | **描述**                                              |
+| ---------------------- | ------------------------------------------------------------ |
+| type                   | 资源类型。将值设置为 `iceberg`。               |
+| iceberg.catalog.type | 资源的 catalog 类型。支持 Hive catalog 和自定义 catalog。如果指定 Hive catalog，将值设置为 `HIVE`。如果指定自定义 catalog，将值设置为 `CUSTOM`。 |
+| iceberg.catalog-impl   | 自定义 catalog 的完全限定类名。FE 根据此名称搜索 catalog。如果 catalog 包含自定义配置项，则在创建 Iceberg 外部表时必须将其作为键值对添加到 `PROPERTIES` 参数中。 |
+
+例如，创建名为 `iceberg0` 的资源，并将 catalog 类型设置为 `HIVE`。
+
+- 如果 Iceberg 表的元数据从 Hive metastore 获取，您可以创建一个资源并将 catalog 类型设置为 `HIVE`。
+
+- 地理相关查询
+
+- 创建名为 `hive0` 的 Hive 资源。
+
+示例：在 `hive0` 资源对应的 Hive 集群中，在 `rawdata` 数据库下创建外部表 `profile_parquet_p7`。
+
+**esquery 函数** 用于将查询下推**无法用 SQL 表达的** （如 match 和 geoshape）到 Elasticsearch 进行过滤。esquery 函数的第一个参数用于关联索引。第二个参数是基本 Query DSL 的 JSON 表达式，用括号{} 括起来。**JSON 表达式必须有且只有一个根键**，例如 match、geo_shape 或 bool。
+
+有关支持的数据类型以及 StarRocks 与目标数据库之间的数据类型映射，请参见 [数据类型映射](External_table.md#Data type mapping)。
+
+这是一个示例 Markdown 文档，用于演示各种 Markdown 元素，以测试翻译工具。
+
+## 简介
+
+欢迎使用**Markdown 翻译器** 测试文档！该文件包含各种 Markdown 元素，以确保翻译能够正确保留格式。
+
+### 待测试功能
+
+以下是我们希望验证的关键功能：
+
+1. **标题** 不同级别的
+2. *斜体* 和 **粗体** 文本格式
+3. `Inline code` 代码片段
+4. 列表（有序和无序）
+5. 链接和图片
+6. 代码块
+7. 表格
+8. 块引用
+
+## 代码示例
+
+这是一个不应被翻译的 JavaScript 函数：
+
+```javascript
+function greetUser(name) {
+    console.log(`Hello, ${name}! Welcome to the translator.`);
+    return `Greeting sent to ${name}`;
+}
+```
+
+这是一些 Python 代码：
+
+```python
+def calculate_total(items):
+    """Calculate the total price of items."""
+    total = sum(item['price'] for item in items)
+    return total
+```
+
+## 列表
+
+### 无序列表
+
+- 列表中的第一项
+- 第二项，包含**粗体文本**
+- 第三项，包含[一个链接](https://example.com)
+- 第四项，包含 `inline code`
+
+### 有序列表
+
+1. 流程中的第一步
+2. 第二步，包含*强调*
+3. 最后一步，包含重要细节
+
+## 表格
+
+| 功能 | 描述 | 状态 |
+|---------|-------------|--------|
+| 翻译 | 将文本转换为目标语言 | ✅ 启用 |
+| 格式化 | 保留 Markdown 结构 | ✅ 启用 |
+| 代码块 | 保持代码不被翻译 | ✅ 启用 |
+| 链接 | 维护 URL 完整性 | ✅ 启用 |
+
+## 链接和图片
+
+访问我们的[文档](https://github.com/example/markdown-translator) 以获取更多信息。
+
+![示例图片](https://via.placeholder.com/300x200?text=Sample+Image)
+
+## Docusaurus 提示框
+
+:::tip
+如果 MinIO Web UI 中没有显示访问密钥，请检查 `minio_mc` 服务的日志：
+
+```bash
+docker compose logs minio_mc
+```
+
+尝试重新运行 `minio_mc` Pod：
+
+```bash
+docker compose run minio_mc
+```
+
+:::
+
+## 块引用
+
+> 这是一段重要的引用，应在保留块引用格式的同时进行翻译。
+>
+> 多段落引用也应能正常工作。
+
+### 嵌套块引用
+
+> 这是一段主要引用。
+>
+> > 这是主要引用中的嵌套引用。
+它应保持正确的嵌套结构。
+
+## 混合内容
+
+您可以将 `inline code` 与 **粗体文本** 和 *斜体文本* 组合在同一段落中。URL（如 https://example.com）应保持不变，电子邮件地址（如 contact@example.com）也应保持不变。
+
+## 技术术语
+
+在处理技术文档时，诸如 **API**、**JSON**、**HTTP** 和 **URL** 等术语可能需要根据目标语言和上下文进行特殊处理。
+
+本示例还特意包含了几个不得翻译的项目专有术语：StarRocks、Hive、Leader、Follower、Raft、Docker、Kubernetes、MinIO。
+
+使用中文词典中常见英文术语的附加示例句子：
+
+- 数据加载在管道的摄取阶段执行。
+- 数据卸载将结果导出到外部系统以供下游处理。
+- 原生表使用系统内部格式存储数据。
+- 云原生表部署将存储与计算分离以实现可扩展性。
+- 外部表允许查询存储在数据库之外的数据。
+- Hive 外部表可用于访问旧版 Hive 数据集。
+- 存储分层有助于优化冷热数据的存放位置。
+- 存储与计算的分离实现了灵活的扩展能力。
+- 在共享数据模式下，多个计算集群访问同一存储。
+- 零迁移策略可在升级期间最大限度地减少停机时间。
+- 原生向量化引擎加速分析查询。
+- 查询联邦允许跨不同系统连接表。
+- 列式存储提高了压缩率和分析性能。
+- 行式存储适用于事务性工作负载。
+- 物化视图可以预计算开销较大的聚合操作。
+- 预聚合通过提前汇总数据来减少查询时的计算量。
+- 聚合查询对多组行计算汇总结果。
+- 星型模式是一种常见的用于分析的维度建模模式。
+- 雪花模式对维度表进行规范化以减少冗余。
+- 点查询通过键检索单行或少量行。
+
+### 带解释的代码
+
+以下命令用于安装该软件包：
+
+```bash
+npm install markdown-translator
+```
+
+此命令应保持原样不变，但此说明文字应被翻译。
+
+## 结论
+
+本示例文档测试各种 Markdown 元素，以确保翻译工具正常运行。目标是翻译所有可读文本，同时保留：
+
+- Markdown 格式
+- 代码块和内联代码
+- URL 和文件路径
+- 技术语法
+
+***
+
+*本文档是为测试目的而创建的。*
+
+# 外部表
+
+执行以下语句以创建名为 `jdbc0` 的 JDBC 资源：
+
+在创建资源时，FE 使用 `driver_url` 参数中指定的 URL 下载 JDBC 驱动程序 JAR 包，生成校验和，并使用该校验和验证 BE 下载的 JDBC 驱动程序。
+
+从 2.5 版本开始，StarRocks 提供数据缓存功能，可加速对外部数据源的热数据查询。更多信息，请参见 [数据缓存](data_cache.md)。
+
+当 BE 首次查询 JDBC 外部表，发现其机器上不存在对应的 JDBC 驱动程序 JAR 包时，BE 会使用 `driver_url` 参数中指定的 URL 下载 JDBC 驱动程序 JAR 包，所有 JDBC 驱动程序 JAR 包均保存在 `${STARROCKS_HOME}/lib/jdbc_drivers` 目录中。
+
+> 注意：`ResourceType` 列为 `jdbc`。
+
+执行以下语句以删除名为 `jdbc0` 的 JDBC 资源：
+
+执行以下语句以在 StarRocks 中创建并访问名为 `jdbc_test` 的数据库：
+
+执行以下语句以在数据库 `jdbc_test` 中创建名为 `jdbc_tbl` 的 JDBC 外部表：
+
+`properties` 中的必填参数如下：
+
+执行以下语句以删除名为 `hudi0` 的 Hudi 资源：
+
+执行以下语句以在您的 StarRocks 集群中创建并打开名为 `hudi_test` 的 Hudi 数据库：
+
+下表描述了各参数。
+
+| 参数 | 描述                                                  |
+| --------- | ------------------------------------------------------------ |
+| ENGINE    | Hudi 外部表的查询引擎。将值设置为 `HUDI`。 |
+| resource  | StarRocks 集群中 Hudi 资源的名称。     |
+| database  | Hudi 外部表在 StarRocks 集群中所属的 Hudi 数据库名称。 |
+| table     | 与 Hudi 外部表关联的 Hudi 托管表。 |
+
+| Hudi 支持的数据类型   | StarRocks 支持的数据类型 |
+| ----------------------------   | --------------------------------- |
+| BOOLEAN                        | BOOLEAN                           |
+| INT                            | TINYINT/SMALLINT/INT              |
+| DATE                           | DATE                              |
+| TimeMillis/TimeMicros          | TIME                              |
+| TimestampMillis/TimestampMicros| DATETIME                          |
+| LONG                           | BIGINT                            |
+| FLOAT                          | FLOAT                             |
+| DOUBLE                         | DOUBLE                            |
+| STRING                         | CHAR/VARCHAR                      |
+| ARRAY                          | ARRAY                             |
+| DECIMAL                        | DECIMAL                           |
+
+:::note
+
+StarRocks 不支持查询 STRUCT 或 MAP 类型的数据，也不支持查询 Merge On Read 表中 ARRAY 类型的数据。
+
+:::
+
+> **注意**
+>
+> StarRocks 不支持查询 STRUCT 或 MAP 类型的数据，也不支持查询 Merge On Read 表中 ARRAY 类型的数据。
+
+:::note
+
+外部表功能除某些特殊使用场景外不再推荐使用，未来版本中可能会被弃用。在一般场景下，若需管理和查询外部数据源的数据，[外部目录](./catalog/catalog_overview.md) 是推荐的方式。
+
+:::
+
+下表描述了各参数。
+
+| **参数**        | **是否必填** | **默认值** | **描述**                                              |
+| -------------------- | ------------ | ----------------- | ------------------------------------------------------------ |
+| hosts                | 是          | 无              | Elasticsearch 集群的连接地址。您可以指定一个或多个地址。StarRocks 可以从该地址解析 Elasticsearch 版本和索引分片分配。StarRocks 根据 `GET /_nodes/http` API 操作返回的地址与您的 Elasticsearch 集群通信。因此，`host` 参数的值必须与 `GET /_nodes/http` API 操作返回的地址相同。否则，BE 可能无法与您的 Elasticsearch 集群通信。 |
+| index                | 是          | 无              | 在 StarRocks 表上创建的 Elasticsearch 索引名称。名称可以是别名。此参数支持通配符 (*)。例如，如果将 `index` 设置为 <code class="language-text">hello*</code>，StarRocks 将检索所有名称以 `hello` 开头的索引。 |
+| user                 | 否           | 空             | 在启用基本身份验证的情况下登录 Elasticsearch 集群所使用的用户名。请确保您具有访问 `/*cluster/state/*nodes/http` 和索引的权限。 |
+| password             | 否           | 空             | 登录 Elasticsearch 集群所使用的密码。 |
+| type                 | 否           | `_doc`            | 索引的类型。默认值：`_doc`。如果您要查询 Elasticsearch 8 及更高版本中的数据，则无需配置此参数，因为 Elasticsearch 8 及更高版本中已移除映射类型。 |
+| es.nodes.wan.only    | 否           | `false`           | 指定 StarRocks 是否仅使用 `hosts` 指定的地址访问 Elasticsearch 集群并获取数据。<ul><li>`true`：StarRocks 仅使用 `hosts` 指定的地址访问 Elasticsearch 集群并获取数据，不会探测 Elasticsearch 索引分片所在的数据节点。如果 StarRocks 无法访问 Elasticsearch 集群内部数据节点的地址，则需要将此参数设置为 `true`。</li><li>`false`：StarRocks 使用 `host` 指定的地址探测 Elasticsearch 集群索引分片所在的数据节点。StarRocks 生成查询执行计划后，相关 BE 直接访问 Elasticsearch 集群内部的数据节点，从索引分片中获取数据。如果 StarRocks 可以访问 Elasticsearch 集群内部数据节点的地址，建议保留默认值 `false`。</li></ul> |
+| es.net.ssl           | 否           | `false`           | 指定是否可以使用 HTTPS 协议访问您的 Elasticsearch 集群。仅 StarRocks 2.4 及更高版本支持配置此参数。<ul><li>`true`：可以使用 HTTPS 和 HTTP 协议访问您的 Elasticsearch 集群。</li><li>`false`：只能使用 HTTP 协议访问您的 Elasticsearch 集群。</li></ul> |
+| enable_docvalue_scan | 否           | `true`            | 指定是否从 Elasticsearch 列式存储中获取目标字段的值。在大多数情况下，从列式存储读取数据的性能优于从行式存储读取数据。 |
+| enable_keyword_sniff | 否           | `true`            | 指定是否根据 KEYWORD 类型字段对 Elasticsearch 中的 TEXT 类型字段进行探测。如果此参数设置为 `false`，StarRocks 将在分词后执行匹配。 |
+
+|   SQL 语法  |   ES 语法  |
+| :---: | :---: |
+|  `=`   |  term query   |
+|  `in`   |  terms query   |
+|  `>=,  <=, >, <`   |  range   |
+|  `and`   |  bool.filter   |
+|  `or`   |  bool.should   |
+|  `not`   |  bool.must_not   |
+|  `not in`   |  bool.must_not + terms   |
+|  `esquery`   |  ES Query DSL  |
+
+> 注意：
+>
+> - 目前，支持的 Hive 存储格式为 Parquet、ORC 和 CSV。
+如果存储格式为 CSV，则不能使用引号作为转义字符。
+> - 支持 SNAPPY 和 LZ4 压缩格式。
+> - 可查询的 Hive 字符串列的最大长度为 1 MB。如果字符串列超过 1 MB，将作为空列处理。
+
+`k4` 的第一个字段为 TEXT 类型，数据写入后将由为 `k4` 配置的分析器（如果未为 `k4` 配置分析器，则使用标准分析器）进行分词。因此，第一个字段将被分词为三个词项：`StarRocks`、`On` 和 `Elasticsearch`。详细信息如下：
+
+- **user:** 此参数指定用于访问目标 StarRocks 集群的用户名。
+- **password:** 此参数指定用于访问目标 StarRocks 集群的密码。
+- **database:** 此参数指定目标表所属的数据库。
+- **table:** 此参数指定目标表的名称。
+
+```SQL
+# 在目标 StarRocks 集群中创建目标表。
+CREATE TABLE t
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    k4 VARCHAR(2048),
+    k5 DATETIME
+)
+ENGINE=olap
+DISTRIBUTED BY HASH(k1);
+
+# 在源 StarRocks 集群中创建外部表。
+CREATE EXTERNAL TABLE external_t
+(
+    k1 DATE,
+    k2 INT,
+    k3 SMALLINT,
+    k4 VARCHAR(2048),
+    k5 DATETIME
+)
+ENGINE=olap
+DISTRIBUTED BY HASH(k1)
+PROPERTIES
+(
+    "host" = "127.0.0.1",
+    "port" = "9020",
+    "user" = "user",
+    "password" = "passwd",
+    "database" = "db_test",
+    "table" = "t"
+);
+
+# 通过向 StarRocks 外部表写入数据，将数据从源集群写入目标集群。建议在生产环境中使用第二条语句。
+insert into external_t values ('2020-10-11', 1, 1, 'hello', '2020-10-11 10:00:00');
+insert into external_t select * from other_table;
+```
+
+## 参考资料
+
+- [SHOW CREATE TABLE](SHOW_CREATE_TABLE.md)
+- [SHOW TABLES](SHOW_TABLES.md)
+- [USE](../Database/USE.md)
+- [ALTER TABLE](ALTER_TABLE.md)
+- [DROP TABLE](DROP_TABLE.md)


### PR DESCRIPTION
Added a comprehensive Markdown document for testing translation tools, including examples of various markdown elements and their intended formatting.